### PR TITLE
Update v2ray-core url

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -2,7 +2,7 @@
 
 # Download and install V2Ray
 mkdir /tmp/v2ray
-curl -L -H "Cache-Control: no-cache" -o /tmp/v2ray/v2ray.zip https://github.com/v2ray/v2ray-core/releases/latest/download/v2ray-linux-64.zip
+curl -L -H "Cache-Control: no-cache" -o /tmp/v2ray/v2ray.zip https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-64.zip
 unzip /tmp/v2ray/v2ray.zip -d /tmp/v2ray
 install -m 755 /tmp/v2ray/v2ray /usr/local/bin/v2ray
 install -m 755 /tmp/v2ray/v2ctl /usr/local/bin/v2ctl


### PR DESCRIPTION
Please refer to https://github.com/v2fly/v2ray-core/releases for further updates instead of the V2Ray release page. Currently, update in V2Fly will be mirrored to the V2Ray release page but this will NOT continue indefinitely.