### PR TITLE
use wget instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 
 ADD configure.sh /configure.sh
 
-RUN apk add --no-cache ca-certificates curl unzip \
+RUN apk add --no-cache ca-certificates curl unzip wget \
  && chmod +x /configure.sh
 
 CMD /configure.sh

--- a/configure.sh
+++ b/configure.sh
@@ -2,7 +2,7 @@
 
 # Download and install V2Ray
 mkdir /tmp/v2ray
-curl -L -H "Cache-Control: no-cache" -o /tmp/v2ray/v2ray.zip https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-64.zip
+wget -q https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-64.zip -O /tmp/v2ray/v2ray.zip
 unzip /tmp/v2ray/v2ray.zip -d /tmp/v2ray
 install -m 755 /tmp/v2ray/v2ray /usr/local/bin/v2ray
 install -m 755 /tmp/v2ray/v2ctl /usr/local/bin/v2ctl


### PR DESCRIPTION
`curl` doesn't work on the heroku or alpine. I did not investigate this matter in depth

there are the error messages:

```
2021-04-14T13:48:35.406231+00:00 heroku[web.1]: Process exited with status 127
2021-04-14T13:48:35.460623+00:00 heroku[web.1]: State changed from starting to crashed
2021-04-14T13:48:35.362744+00:00 app[web.1]: curl: (27) Out of memory
2021-04-14T13:48:35.363925+00:00 app[web.1]: unzip:  cannot find or open /tmp/v2ray/v2ray.zip, /tmp/v2ray/v2ray.zip.zip or /tmp/v2ray/v2ray.zip.ZIP.
2021-04-14T13:48:35.364624+00:00 app[web.1]: install: can't stat '/tmp/v2ray/v2ray': No such file or directory
2021-04-14T13:48:35.364978+00:00 app[web.1]: install: can't stat '/tmp/v2ray/v2ctl': No such file or directory
2021-04-14T13:48:35.367042+00:00 app[web.1]: /configure.sh: line 44: /usr/local/bin/v2ray: not found
```

and I run an one-off dyno to verify this problem. `curl` even can not visit `google.com`. the same error message shows: `curl: (27) Out of memory`. just one line error message.